### PR TITLE
support loop forever in waveChainTx

### DIFF
--- a/SIF.js
+++ b/SIF.js
@@ -20,6 +20,7 @@ const CMDS = {
   WVAG:   28, // waveAddPulse
   WVAS:   29, // waveAddSerial
   WVBSY:  32, // waveBusy, waveNotBusy
+  WVHLT:  33, // waveTxStop
   SLRO:   42, // serialReadOpen
   SLR:    43, // serialRead
   SLRC:   44, // serialReadClose

--- a/pigpio-client.js
+++ b/pigpio-client.js
@@ -14,7 +14,7 @@ const ERR = SIF.PigpioErrors
 const { BR1, BR2, TICK, HWVER, PIGPV, PUD, MODES, MODEG, READ, WRITE, PWM, WVCLR,
 WVCRE, WVBSY, WVAG, WVCHA, NOIB, NB, NP, NC, SLRO, SLR, SLRC, SLRI, WVTXM, WVTAT,
 
-WVDEL, WVAS, HP, HC, GDC, PFS, FG, SERVO, GPW} = SIF.Commands
+WVHLT, WVDEL, WVAS, HP, HC, GDC, PFS, FG, SERVO, GPW} = SIF.Commands
 
 // These command types can not fail, ie, return p3 as positive integer
 const canNeverFailCmdSet = new Set([HWVER, PIGPV, BR1, BR2, TICK])
@@ -752,6 +752,9 @@ exports.pigpio = function (pi) {
         request(WVCHA, 0, 0, arrBuf.byteLength, callback, arrBuf)
       }
 
+      this.waveTxStop = function (cb) {
+        request(WVHLT, 0, 0, 0, cb)
+      }
       this.waveSendSync = function (wid, cb) {
         request(WVTXM, wid, PI_WAVE_MODE_ONE_SHOT_SYNC, 0, cb)
       }

--- a/pigpio-client.js
+++ b/pigpio-client.js
@@ -727,8 +727,12 @@ exports.pigpio = function (pi) {
           if (param.hasOwnProperty('loop')) {
             temp = chain.concat(255, 0)
           } else if (param.hasOwnProperty('repeat')) {
-            assert.equal(param.repeat <= 0xffff, true, 'param must be <= 65535')
-            temp = chain.concat(255, 1, param.repeat & 0xff, param.repeat >> 8)
+            if (param.repeat === true) {
+              temp = chain.concat(255, 3)            
+            } else {
+              assert.equal(param.repeat <= 0xffff, true, 'param must be <= 65535')
+              temp = chain.concat(255, 1, param.repeat & 0xff, param.repeat >> 8)
+            }
           } else if (param.hasOwnProperty('delay')) {
             assert.equal(param.delay <= 0xffff, true, 'param must be <= 65535')
             temp = chain.concat(255, 2, param.delay & 0xff, param.delay >> 8)

--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,9 @@ waveform. [`gpioWaveTxSend` with mode set to PI_WAVE_MODE_ONE_SHOT_SYNC.](http:/
 **`gpio.waveTxAt(cb)`**  Return currently active wave id, no wave being transmitted 
 (9999) or wave not found (9998). [`gpioWaveTxAt`](http://abyz.me.uk/rpi/pigpio/cif.html#gpioWaveTxAt)  
 
+**`gpio.waveTxStop(cb)`**  Aborts the transmission of the current waveform.
+This function is intended to stop a waveform started in repeat mode. [`waveTxStop`](http://abyz.me.uk/rpi/pigpio/cif.html#gpioWaveTxStop)  
+
 **`gpio.waveDelete(wid, cb)`**  Delete the wave id `wid`. [`gpioWaveDelete`](http://abyz.me.uk/rpi/pigpio/cif.html#gpioWaveDelete)  
 
 *Note:  `waveClear`, `waveCreate` and `waveBusy` are not gpio specific.  These methods 


### PR DESCRIPTION
Enables looping forever by passing a `{repeat: true}` element to `waveChainTx()`