### PR TITLE
Add hardware PWM functionality

### DIFF
--- a/examples/hardwarePWM.js
+++ b/examples/hardwarePWM.js
@@ -1,0 +1,32 @@
+// npm run-script usage
+//const pigpio = require('../pigpio-client').pigpio({host: process.env.npm_package_config_host});
+
+const pigpio = require('../pigpio-client').pigpio({host: "192.168.1.238"});  
+
+const ready = new Promise((resolve, reject) => {
+  pigpio.once('connected', resolve);
+  pigpio.once('error', reject);
+});
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+ready.then(async (info) => {
+
+  // control an analogue CV level on GPIO 
+    const cv1 = pigpio.gpio(18);
+    const cv2 = pigpio.gpio(19);
+    
+    var range = 1E6;
+    var freq1 = 1E5;
+    var freq2 = 2E5;
+    var cv2offset = 2E5;
+    
+    await cv1.hardwarePWM(freq1, range/2);
+    await wait(1000);
+    await cv2.hardwarePWM(freq2, range/3);
+    await wait(1000);
+    
+
+}).catch(console.error);

--- a/pigpio-client.js
+++ b/pigpio-client.js
@@ -346,15 +346,13 @@ exports.pigpio = function (pi) {
   // helper functions
   var request = (cmd, p1, p2, p3, cb, extArrBuf) => {
     var bufSize = 16
-      var buf = Buffer.from(Uint32Array.from([cmd, p1, p2, p3]).buffer) // basic
-      console.log("Sending basic buffer " + buf.length);
+    var buf = Buffer.from(Uint32Array.from([cmd, p1, p2, p3]).buffer) // basic
     if (extReqCmdSet.has(cmd)) {
       // following is not true for waveAddSerial!
       // assert.equal(extArrBuf.byteLength, p3, "incorrect p3 or array length");
       bufSize = 16 + extArrBuf.byteLength
       let extBuf = Buffer.from(extArrBuf) // extension
-        buf = Buffer.concat([buf, extBuf])
-        console.log("Sending buffer " + buf.length);
+      buf = Buffer.concat([buf, extBuf])
     }
 
     var promise;
@@ -819,7 +817,7 @@ exports.pigpio = function (pi) {
         var arrBuf = new ArrayBuffer(4)
         var dcBuf = new Uint32Array(arrBuf, 0, 1)
         dcBuf[0] = dutyCycle
-        return request(HP, gpio, freq, 4, callback, dcBuf)
+        return request(HP, gpio, freq, 4, callback, arrBuf)
       }
 
   // Servo pulse width

--- a/pigpio-client.js
+++ b/pigpio-client.js
@@ -352,7 +352,8 @@ exports.pigpio = function (pi) {
       // assert.equal(extArrBuf.byteLength, p3, "incorrect p3 or array length");
       bufSize = 16 + extArrBuf.byteLength
       let extBuf = Buffer.from(extArrBuf) // extension
-      buf = Buffer.concat([buf, extBuf])
+        buf = Buffer.concat([buf, extBuf])
+        console.log("Sending buffer " + buf);
     }
 
     var promise;

--- a/pigpio-client.js
+++ b/pigpio-client.js
@@ -20,7 +20,7 @@ WVHLT, WVDEL, WVAS, HP, HC, GDC, PFS, FG, SERVO, GPW} = SIF.Commands
 const canNeverFailCmdSet = new Set([HWVER, PIGPV, BR1, BR2, TICK])
 
 // These command types have extended command data lengths
-const extReqCmdSet = new Set([WVCHA, WVAG, SLRO, WVAS])
+const extReqCmdSet = new Set([WVCHA, WVAG, SLRO, WVAS, HP])
 
 // These command types have extended response data lengths
 const extResCmdSet = new Set([SLR])
@@ -810,6 +810,14 @@ exports.pigpio = function (pi) {
       }
       this.getPWMdutyCycle = function (cb) {
         return request(GDC, gpio, 0, 0, cb)
+      }
+
+      this.setHardwarePWMdutyCycle = function (dutyCycle, freq, callback) {
+        freq = freq || 100000
+        var arrBuf = new ArrayBuffer(4)
+        var dcBuf = new Uint32Array(arrBuf, 0, 1)
+        dcBuf[0] = dutyCycle
+        return request(HP, gpio, freq, 4, callback, dcBuf)
       }
 
   // Servo pulse width

--- a/pigpio-client.js
+++ b/pigpio-client.js
@@ -347,14 +347,14 @@ exports.pigpio = function (pi) {
   var request = (cmd, p1, p2, p3, cb, extArrBuf) => {
     var bufSize = 16
       var buf = Buffer.from(Uint32Array.from([cmd, p1, p2, p3]).buffer) // basic
-      console.log("Sending basic buffer " + buf);
+      console.log("Sending basic buffer " + buf.length);
     if (extReqCmdSet.has(cmd)) {
       // following is not true for waveAddSerial!
       // assert.equal(extArrBuf.byteLength, p3, "incorrect p3 or array length");
       bufSize = 16 + extArrBuf.byteLength
       let extBuf = Buffer.from(extArrBuf) // extension
         buf = Buffer.concat([buf, extBuf])
-        console.log("Sending buffer " + buf);
+        console.log("Sending buffer " + buf.length);
     }
 
     var promise;

--- a/pigpio-client.js
+++ b/pigpio-client.js
@@ -592,9 +592,6 @@ exports.pigpio = function (pi) {
   that.readBank1 = function (cb) {
     return that.request(BR1, 0, 0, 0, cb)
   }
-  that.hwPWM = function (gpio, freq, dc, cb) {
-    return that.request(HP, gpio, freq, dc, cb)
-  }
   that.hwClock = function (gpio, freq, cb) {
     return that.request(HC, gpio, freq, 0, cb)
   }
@@ -811,13 +808,11 @@ exports.pigpio = function (pi) {
       this.getPWMdutyCycle = function (cb) {
         return request(GDC, gpio, 0, 0, cb)
       }
-
-      this.setHardwarePWMdutyCycle = function (dutyCycle, freq, callback) {
-        freq = freq || 100000
+      this.hardwarePWM = function (frequency, dutyCycle, callback) {
         var arrBuf = new ArrayBuffer(4)
         var dcBuf = new Uint32Array(arrBuf, 0, 1)
         dcBuf[0] = dutyCycle
-        return request(HP, gpio, freq, 4, callback, arrBuf)
+        return request(HP, gpio, frequency, 4, callback, arrBuf)
       }
 
   // Servo pulse width

--- a/pigpio-client.js
+++ b/pigpio-client.js
@@ -346,7 +346,8 @@ exports.pigpio = function (pi) {
   // helper functions
   var request = (cmd, p1, p2, p3, cb, extArrBuf) => {
     var bufSize = 16
-    var buf = Buffer.from(Uint32Array.from([cmd, p1, p2, p3]).buffer) // basic
+      var buf = Buffer.from(Uint32Array.from([cmd, p1, p2, p3]).buffer) // basic
+      console.log("Sending basic buffer " + buf);
     if (extReqCmdSet.has(cmd)) {
       // following is not true for waveAddSerial!
       // assert.equal(extArrBuf.byteLength, p3, "incorrect p3 or array length");

--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ PWM or servo pulses are active on the gpio they are switched off. [`gpioWrite`](
 **`gpio.analogWrite(dutyCycle, cb)`**  Set the PWM dutycycle (0-255) on the gpio.  Caution: 
 This will stop all waveform generation. [`gpioPWM`](http://abyz.me.uk/rpi/pigpio/cif.html#gpioPWM).  
 
-**`gpio.setHardwarePWMdutyCycle(dutyCycle, freq, cb)`**  Set the hardware PWM dutycycle (0-1000000) on the gpio. Only works with pins that support hardware PWM; max two channels available. PWM frequency can also be specified - if not given it will default to 100KHz. Caution: 
+**`gpio.hardwarePWM(frequency, dutyCycle, callback)`**  Set the hardware PWM dutycycle (0-1000000) on the gpio. Only works with pins that support hardware PWM (12,13,18,19); max two channels available. PWM frequency is also specified - not likely to work above 30MHz though. Caution: 
 This will stop all waveform generation. [`gpioHardwarePWM`](http://abyz.me.uk/rpi/pigpio/cif.html#http://abyz.me.uk/rpi/pigpio/cif.html#gpioHardwarePWM).  
 
 **`gpio.setServoPulsewidth(pulseWidth, cb)`** Starts servo pulses on gpio. Pulsewidth can be set to 0 (off) and from 500 (most anti-clockwise) to 2500 (most clockwise). Be aware that you can damage your servo when setting a too high pulseWidth. A value of 1500 (mid-point) is a good starting point to check range of your servo. [`gpioServo`](http://abyz.me.uk/rpi/pigpio/cif.html#gpioServo)  

--- a/readme.md
+++ b/readme.md
@@ -135,6 +135,9 @@ PWM or servo pulses are active on the gpio they are switched off. [`gpioWrite`](
 **`gpio.analogWrite(dutyCycle, cb)`**  Set the PWM dutycycle (0-255) on the gpio.  Caution: 
 This will stop all waveform generation. [`gpioPWM`](http://abyz.me.uk/rpi/pigpio/cif.html#gpioPWM).  
 
+**`gpio.setHardwarePWMdutyCycle(dutyCycle, freq, cb)`**  Set the hardware PWM dutycycle (0-1000000) on the gpio. Only works with pins that support hardware PWM; max two channels available. PWM frequency can also be specified - if not given it will default to 100KHz. Caution: 
+This will stop all waveform generation. [`gpioHardwarePWM`](http://abyz.me.uk/rpi/pigpio/cif.html#http://abyz.me.uk/rpi/pigpio/cif.html#gpioHardwarePWM).  
+
 **`gpio.setServoPulsewidth(pulseWidth, cb)`** Starts servo pulses on gpio. Pulsewidth can be set to 0 (off) and from 500 (most anti-clockwise) to 2500 (most clockwise). Be aware that you can damage your servo when setting a too high pulseWidth. A value of 1500 (mid-point) is a good starting point to check range of your servo. [`gpioServo`](http://abyz.me.uk/rpi/pigpio/cif.html#gpioServo)  
 
 **`gpio.getServoPulsewidth(cb)`** Returns the pulsewidth of gpio as argument to callback. [`gpioGetServoPulsewidth`](http://abyz.me.uk/rpi/pigpio/cif.html#gpioGetServoPulsewidth)  


### PR DESCRIPTION
I haven't changed the version number in package.json or pigpio-client.js, but I presume this would go up to 1.4.0 if the PR is pulled and released.

It might also be worth deleting the `hwPWM` function from the code as it doesn't appear to work. I have left it in for now in case it works for somebody else who relies on it.