### PR TITLE
Add gpio.trigger

### DIFF
--- a/pigpio-client.js
+++ b/pigpio-client.js
@@ -13,7 +13,7 @@ const ERR = SIF.PigpioErrors
 // These commands are currently supported by pigpio-client:
 const { BR1, BR2, TICK, HWVER, PIGPV, PUD, MODES, MODEG, READ, WRITE, PWM, WVCLR,
 WVCRE, WVBSY, WVAG, WVCHA, NOIB, NB, NP, NC, SLRO, SLR, SLRC, SLRI, WVTXM, WVTAT,
-WVHLT, WVDEL, WVAS, HP, HC, GDC, PFS, FG, SERVO, GPW,
+WVHLT, WVDEL, WVAS, HP, HC, GDC, PFS, FG, SERVO, GPW, TRIG,
 I2CO, I2CC, I2CRD, I2CWD, BSCX, EVM
 } = SIF.Commands
 
@@ -705,6 +705,11 @@ exports.pigpio = function (pi) {
       }
       this.modeGet = function (callback) {
         return request(MODEG, gpio, 0, 0, callback)
+      }
+      this.trigger = function (len, level, callback) {
+        const buf = Buffer.allocUnsafe(4);
+        buf.writeUInt32LE(level);
+        return request(TRIG, gpio, len, 4, callback, buf);
       }
   // PWM
       this.analogWrite = function (dutyCycle, cb) {

--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,11 @@ device.
 **`gpio.modeSet(mode, cb)`**  Sets the gpio mode to be input or output.  The mode 
 argument must be `string` with a value of `'input'`, `'in'`, `'output'` or `'out'`.
 The optional callback is invoked with either `null` argument on success or `error` 
-on failure.  
+on failure.
+
+**`gpio.trigger(len, level, cb)`**  Send a trigger pulse to a GPIO. The GPIO is set 
+to `level` for `len` microseconds. The optional callback is invoked with either 
+`null` argument on success or `error` on failure.
 
 **`gpio.modeGet(cb)`**  Returns the mode of gpio as argument to callback. [`gpioGetMode`](http://abyz.me.uk/rpi/pigpio/cif.html#gpioGetMode)  
 


### PR DESCRIPTION
This adds support for gpio.trigger, which allows to set a gpio to level for a given duration.